### PR TITLE
Add custom import method for Comtessa image data

### DIFF
--- a/pyplis/custom_image_import.py
+++ b/pyplis/custom_image_import.py
@@ -250,7 +250,7 @@ def load_usgs_multifits_uncompr(file_path, meta={}):
                       "Error message: %s" %repr(e))
     return (img, meta)
   
-  def _read_binary_timestamp(timestamp):
+def _read_binary_timestamp(timestamp):
     """ Converts an (1,14)-array of pixel as given by the pco camware software to
     a valid datetime 
 


### PR DESCRIPTION
Add a image loading method for multi-layer fits files, distinct to the Comtessa project at NILU.
A second method `_read_binary_timestamp(timestamp)`, which reads a binary timestamp directly from image pixels had to be included as well.
Requires that user parameters can be defined in image class.