### PR TITLE
Add ImgList which handles multi layer fits and some minor changes

### DIFF
--- a/pyplis/custom_image_import.py
+++ b/pyplis/custom_image_import.py
@@ -51,7 +51,7 @@ from warnings import warn
 from astropy.io import fits
 from cv2 import resize
 from os.path import basename
-from datetime import datetime
+from datetime import datetime, timedelta
 from .helpers import matlab_datenum_to_datetime
 
 from re import sub

--- a/pyplis/data/cam_info.txt
+++ b/pyplis/data/cam_info.txt
@@ -278,3 +278,27 @@ reg_shift_off:0.00,0.00
 io_opts:LINK_OFF_TO_ON=1,USE_ALL_FILES=0,INCLUDE_SUB_DIRS=1,SEPARATE_FILTERS=1
 image_import_method:load_ecII_fits
 ENDCAM
+
+
+NEWCAM
+cam_ids:comtessa, nilu, NILU, 
+cam_id:comtessa
+delim:_
+time_info_pos:0
+time_info_str:%Y%m%dZ%H%M
+filter_id_pos:1
+texp_pos:
+texp_unit:
+file_type:fts
+main_filter_id:on
+meas_type_pos:1
+DARK_CORR_OPT:2
+focal_length:25.04
+pix_height:4.65e-06
+pix_width:4.65e-06
+pixnum_x:1392
+pixnum_y:1040
+filter:on,on,A,A,310
+filter:off,off,B,B,330
+image_import_method:load_comtessa
+ENDCAM

--- a/pyplis/image.py
+++ b/pyplis/image.py
@@ -36,6 +36,7 @@ import matplotlib.cm as cmaps
 from matplotlib.pyplot import figure, tight_layout
 from numpy import (ndarray, argmax, histogram, uint, nan, linspace, isnan, 
                    uint8, float32, finfo, ones, invert, log, ogrid, asarray)
+from numpy.ma import masked_array
 from json import loads, dumps
 from os.path import abspath, splitext, basename, exists, join, isdir, dirname
 from os import remove
@@ -632,6 +633,28 @@ class Img(object):
         """
         self.img = gaussian_filter(self.img, sigma, **kwargs)
         self.edit_log["blurring"] += sigma   
+    
+    def get_masked_img(self, mask, fill_value=None):
+        """ Returns a np.ma.masked_array of the img array
+        Parameters:
+        -----------
+        mask : numpy.ndarray
+            entries which should be masked (True=invalid entry)
+            has to be same shape as current state of self.img
+        fill_value : float
+            (optional, default None) If defined, invalid entries are replaced 
+            by fill_value
+        Returns:
+        --------
+        numpy.ma.masked_array
+            masked array
+        """
+        data = deepcopy(self.img)
+        data_masked = masked_array(data, mask)
+        if fill_value is None:
+            return data_masked
+        else:
+            return data_masked.filled(fill_value=fill_value)           
     
     def get_thresh_mask(self, threshold):
         """Apply threshold and get binary mask"""

--- a/pyplis/image.py
+++ b/pyplis/image.py
@@ -397,6 +397,7 @@ class Img(object):
             if any([isinstance(input, x) for x in [str, unicode]]) and\
                                                                 exists(input):
                 self.load_file(input)
+                print(input)
             
             elif isinstance(input, ndarray):
                 if self.dtype is not None:

--- a/pyplis/imagelists.py
+++ b/pyplis/imagelists.py
@@ -29,6 +29,7 @@ current and next image).
 #from __future__ import division
 from numpy import (asarray, zeros, argmin, arange, ndarray, float32, isnan,
                    logical_or, uint8, exp, ones)
+from numpy.ma import nomask
 from datetime import timedelta, datetime, date
 
 from pandas import Series, DataFrame
@@ -123,6 +124,7 @@ class BaseImgList(object):
         self._list_modes = {} #init for :class:`ImgList` object
         
         self._vign_mask = None #a vignetting correction mask can be stored here
+        self.__sky_mask = nomask # mask for invalid pixel
         self.loaded_images = {"this"  :    None}
         
         #used to store the img edit state on load
@@ -308,7 +310,22 @@ class BaseImgList(object):
             else:
                 value.pyr_up(pyrlevel_rel)
         self._vign_mask = value
-        
+
+    @property
+    def sky_mask(self):
+        """Sky access mask: 0 for sky, 1 for non-sky (=invalid)
+        (in masked arrays, entries marked with 1 are invalid) """
+        return self.__sky_mask
+    
+    @sky_mask.setter
+    def sky_mask(self, value):
+        # TODO: Check if the mask has the same dimension as the images
+        # TODO: maybe load as pyplis img
+        if not isinstance(value, ndarray):
+            raise TypeError("Could not set sky_mask, need MeasGeometry "
+                "object")
+        self.__sky_mask = deepcopy(value)
+    
     @property
     def integration_step_length(self):
         """The integration step length for emission-rate analyses

--- a/pyplis/imagelists.py
+++ b/pyplis/imagelists.py
@@ -104,7 +104,7 @@ class BaseImgList(object):
         self._integration_step_lengths = None
         self._plume_dists = None
         
-        self.set_camera(camera)
+        self.set_camera(camera=camera, cam_id=None)
         
         self._update_cam_geodata = False
         self._edit_active = True
@@ -781,7 +781,7 @@ class BaseImgList(object):
         Two options:
             
             1. set :obj:`Camera` directly
-            #. provide one of the default camera IDs (e.g. "ecII", "hdcam")
+            2. provide one of the default camera IDs (e.g. "ecII", "hdcam")
         
         Parameters
         ----------
@@ -793,9 +793,20 @@ class BaseImgList(object):
             camera IDs)
             
         """
-        if not isinstance(camera, Camera):
-            camera = Camera(cam_id)
-        self.camera = camera
+        if camera is not None:
+            if not isinstance(camera, Camera):
+                raise TypeError("Camera argument for image list was not correctly "
+                     "initialised with an object of type pyplis.Camera ")
+                
+            self.camera = camera
+
+        else:
+            if cam_id is not None:
+                self.camera = Camera(cam_id)
+        
+        #if not isinstance(camera, Camera):
+        #    camera = Camera(cam_id)
+        #self.camera = camera
     
     def reset_img_prep(self):
         """Init image pre-edit settings"""
@@ -3798,7 +3809,223 @@ class CellImgList(ImgList):
         self.cell_id = cell_id
         self.gas_cd = gas_cd
         self.gas_cd_err = gas_cd_err
+
+
+from numpy import size, array
+from pandas import to_datetime, concat
+from astropy.io import fits
+from custom_image_import import _read_binary_timestamp
+
+class ImgListLayered(ImgList):
+    """ Image list object able to deal with multi layered fits files
+    
+    Additional features:
         
+            1. Indexing using double index: Filename and image layer
+            2. Function which returns a DataFrame of all available data
+            
+    Parameters
+    ----------
+    files : list
+        list containing image file paths, defaults to ``[]`` (i.e. empty list)
+    meta : DataFrame
+        meta data from a previous load of the same image list. Can be used 
+        alternatively for a faster initialisation
+    list_id : :obj:`str`, optional
+        string ID of this list, defaults to None
+    list_type : :obj:`str`, optional
+        string specifying type of image data in this list (e.g. on, off)
+    camera : :obj:`Camera`, optional
+        camera specifications, defaults to None
+    geometry : :obj:`MeasGeometry`, optional
+        measurement geometry
+    init : bool
+        if True, the first two images in list ``files`` are loaded
+        
+    Note
+    ----
+    Initialise with a list of n files each containing a (variable) 
+    number of image layers) m_n. The file header needs to be read in for 
+    every file in order to get the right amount of total images. The
+    attribute `self.files` will contain m_n copies of the file n.
+    If the list has been loaded before, the ImgListLayered can also be 
+    initialised with a DataFrame containing all meta information.
+        
+    """
+    
+    def __init__(self, files=[], meta=None, list_id=None, list_type=None, camera=None,
+                 geometry=None, init=True):
+        # uses the init method from ImgList but does not load the files!
+        super(ImgListLayered, self).__init__(files, list_id, list_type, camera, 
+                                      geometry, init=False)
+        
+        self.fitsfiles = files
+        
+        if isinstance(meta, DataFrame):
+            try:
+                self.metaData = meta
+            except:
+                self.metaData = self.get_img_meta_all()
+        else:
+            self.metaData = self.get_img_meta_all()
+
+        # Image referencing by two information: file and image layer
+        # filename subindex (file is repeated m_n times)
+        self.files = self.metaData['file'].values
+        # image layer inside fits file
+        self.hdu_nr = self.metaData['hdu_nr'].values
+                                      
+        if self.data_available and init:
+            self.load()    
+
+    def get_img_meta_from_filename(self, file_path):
+        """Loads and prepares img meta input dict for Img object
+        
+        Note
+        ----
+        Convenience method only rewritten in order to not break the code.
+        Loads meta data of first image plane in fits file_path
+        
+        Parameters
+        ----------
+        file_path : str 
+            file path of image
+        
+        Returns
+        -------
+        dict
+            dictionary containing retrieved values for ``start_acq`` and 
+            ``texp``
+        """
+        
+        warn('This method does not make a lot of sense for the ImgListLayered!'
+             ' Returns the meta data of the first image in file_path.'
+             ' Use metaData attribute to access meta information instead.')
+        
+        hdulist = fits.open(file_path)
+        # Load the image
+        image = hdulist[0].data
+        time = _read_binary_timestamp(image) 
+        texp = float(hdulist[0].header['EXP']) / 1000. # in s
+        return {"start_acq" : time, "texp": texp}
+    
+    
+        
+    def get_img_meta_all_filenames(self):   
+        """ returns the same data as expected from 
+        ImgList.get_img_meta_all_filenames()
+        
+        Note
+        ----
+        Convenience method only rewritten in order to not break the code
+        
+        Returns
+        -------
+        tuple
+            2-element tuple containing
+            
+            - list, list containing all retrieved acq. time stamps
+            - list, containing all retrieved exposure times
+        """
+        meta = self.metaData
+        times = meta.start_acq.values
+        texps = meta.exposure.values         
+        return times, texps
+    
+    def get_img_meta_one_fitsfile(self, file_path):
+        """ Load all meta data from all image layers of one fits file.
+        In this form it is custom for the comtessa files
+        TODO: Make general for multilayered fits """
+        
+        # temporary lists of parameters
+        imgFileStart = []
+        imgFileStop = []
+        imgFileMin = []
+        imgFileMax = []
+        imgFileMean = []
+        imgFileExp = []
+        imgFileTemp = []
+        
+        #open the file, returning a list containg Header-Data Units (HDU)
+        hdulist = fits.open(file_path)
+        imgPerFile = size(hdulist)
+#            hdulist.close()
+        for hdu in range(imgPerFile):
+            # Info from image
+            image = hdulist[hdu].data    
+            imgFileStop.append(_read_binary_timestamp(image))
+            image[0,0:14] = image[1,0:14] #replace binary timestamp
+            imgFileMin.append(image.min())
+            imgFileMax.append(image.max())
+            imgFileMean.append(image.mean())
+            # Info from header
+            imageHeader = hdulist[hdu].header
+            imgFileStart.append(imgFileStop[-1] - timedelta(microseconds=int(imageHeader['EXP'])*1000))
+            imgFileExp.append(float(imageHeader['EXP']) / 1000.) # in s
+            imgFileTemp.append(float(imageHeader['TCAM']))
+        
+        # Combine the temporary lists to a dataFrame and return it
+        meta = DataFrame(data={'file'       : [file_path]*imgPerFile,
+                               'hdu_nr'     : array(range(imgPerFile),dtype=int),
+                               'start_acq'  : imgFileStart,
+                               'stop_acq'   : imgFileStop,
+                               'exposure'   : imgFileExp,
+                               'temperature': imgFileTemp,
+                               'min'        : imgFileMin,
+                               'max'        : imgFileMax,
+                               'mean'       : imgFileMean},
+                            index=imgFileStart)
+        meta.index = to_datetime(meta.index)
+        return meta
+        
+    
+    def get_img_meta_all(self):
+        """ Load all available meta data from fits files            
+        Returns
+        -------
+        dataFrame
+            containing all metadata
+        """
+        
+        if self.fitsfiles == []:
+            print("ImgListLayered was intialised without providing the "
+                  "fitsfile (e.g. only by meta file). self.get_img_meta_all "
+                  "will return the existing metaData.")
+            return self.metaData
+        
+        # Exatract information of every image in every fits file in fitsFile
+        meta_single = [self.get_img_meta_one_fitsfile(file_path) for file_path in self.fitsfiles]
+        meta = concat(meta_single)
+        meta['img_id'] = arange(0,len(meta),1)
+        meta.index = to_datetime(meta.index)
+        return meta
+
+    
+    def _load_image(self, list_index):
+        """ Loads a single image
+        
+        Parameters
+        ----------
+        index : int
+            index of image which should be loaded
+        Returns
+        -------
+        Img
+            loaded image including meta data
+         """
+        img_file = self.files[list_index]
+        img_hdu = self.hdu_nr[list_index]
+        meta = {}
+        meta["fits_idx"] = img_hdu
+        meta["filter_id"] = self.list_id
+        try:
+            image =  Img(input=img_file,
+                         import_method=self.camera.image_import_method,                            
+                         **meta)
+        except:
+            warn('Could not load image with self.camera.image_import_method.')
+        return image
+
 # OLD version of ImgList before major changes (stamp: 3/3/2018)    
 # =============================================================================
 # class ImgList(BaseImgList):

--- a/pyplis/plumespeed.py
+++ b/pyplis/plumespeed.py
@@ -2419,6 +2419,7 @@ class OptflowFarneback(object):
         #print "Calculating Farneback optical flow"
         self.flow = calcOpticalFlowFarneback(self.images_prep["this"],
                                              self.images_prep["next"], 
+                                             flow=None,
                                              flags=OPTFLOW_FARNEBACK_GAUSSIAN,
                                              **settings)
         return self.flow 

--- a/pyplis/setupclasses.py
+++ b/pyplis/setupclasses.py
@@ -524,6 +524,11 @@ class Camera(CameraBaseInfo):
     def __init__(self, cam_id=None, filter_list=[], default_filter_on=None,
                  default_filter_off=None, ser_no=9999, **geom_info):
         
+        if cam_id is not None:
+            if not isinstance(cam_id, str):
+                raise TypeError("Camera initialisation: cam_id argument has "
+                                "to be of type str or None")
+            
         super(Camera, self).__init__(cam_id)
     
         #specify the filters used in the camera and the main filter (e.g. On)        

--- a/pyplis/test/test_image_module.py
+++ b/pyplis/test/test_image_module.py
@@ -58,14 +58,14 @@ def binary_mask(scope='module'):
 @pytest.mark.parametrize("fill_value", [
         0.0, 10, -1.234])
     
-def test_masked_img(ec2_img, mask, fill_value):
+def test_masked_img(ec2_img, binary_mask, fill_value):
     """ Test if masking works """
-    masked_img = ec2_img.get_masked_img(mask=mask, fill_value=fill_value)
+    masked_img = ec2_img.get_masked_img(mask=binary_mask, fill_value=fill_value)
     assert masked_img[200, 500] == fill_value
 
-def test_masked_img_nan(ec2_img, mask):
+def test_masked_img_nan(ec2_img, binary_mask):
     """ Test if masking works """
-    masked_img = ec2_img.get_masked_img(mask=mask, fill_value=nan)
+    masked_img = ec2_img.get_masked_img(mask=binary_mask, fill_value=nan)
     assert math.isnan(masked_img[200, 500])
     
     

--- a/pyplis/test/test_image_module.py
+++ b/pyplis/test/test_image_module.py
@@ -9,8 +9,10 @@ License: GPLv3+
 
 from pyplis import Img, __dir__
 from os.path import join, exists
+from numpy import nan, zeros
 from numpy.testing import assert_allclose
 import pytest
+import math
 
 EC2_IMG_PATH = join(__dir__, "data", "test_201509160708_F01_335.fts")
 
@@ -45,9 +47,26 @@ def test_pyramid_crop(ec2_img):
 def test_meta_info(ec2_img):
     """Test if all relevant meta information is loaded"""
     assert ec2_img.shape == (1024, 1344)
-    
-    
 
+@pytest.fixture
+def binary_mask(scope='module'):
+    """ Binary mask for ec2 image """
+    mask = zeros((1024, 1344))
+    mask[0:500,:] = 1
+    return mask
+
+@pytest.mark.parametrize("fill_value", [
+        0.0, 10, -1.234])
+    
+def test_masked_img(ec2_img, mask, fill_value):
+    """ Test if masking works """
+    masked_img = ec2_img.get_masked_img(mask=mask, fill_value=fill_value)
+    assert masked_img[200, 500] == fill_value
+
+def test_masked_img_nan(ec2_img, mask):
+    """ Test if masking works """
+    masked_img = ec2_img.get_masked_img(mask=mask, fill_value=nan)
+    assert math.isnan(masked_img[200, 500])
     
     
     


### PR DESCRIPTION
With the new `ImgListLayered` class it is possible to work with fits files which contain more than one image. It is programmed in a non-invasive way (separate class), as we do not know the full reaction of all modules (we have to write more tests) to changes of the base class. A better way (for the future) would be to integrated this functionality in `ImgList` with e.g. a imglistmode argument. In the current solution, all objects containing `ImgLists` e.g. `CellCalibEngine` cannot be used with `ImgListLayered` and consequently with layered fits files. 

The pull request contains also some other minor adaptions making it possible to mask pixels in the analysis.

PS: Sorry that the "Merge pull requests" are double now, I wasn't sure how to remove them