### PR TITLE
Bug Fix: Setting of calibration coefficients

### DIFF
--- a/pyplis/calib_base.py
+++ b/pyplis/calib_base.py
@@ -190,8 +190,7 @@ class CalibData(object):
                                  "in current optimisation function. "
                                  "Please check and update class attribute "
                                  "calib_fun first...")
-        if self._calib_coeffs is not None:
-            if len(self._calib_coeffs) > 0:
+        if self._calib_coeffs is not None and len(self._calib_coeffs) > 0:
                 warn("Resetting calibration coefficients manually. This may introduce "
                      "analysis errors. It is recommended to use the method "
                      "fit_calib_data instead")

--- a/pyplis/calib_base.py
+++ b/pyplis/calib_base.py
@@ -190,10 +190,11 @@ class CalibData(object):
                                  "in current optimisation function. "
                                  "Please check and update class attribute "
                                  "calib_fun first...")
-        if len(self._calib_coeffs) > 0:
-            warn("Setting calibration coefficients manually. This may introduce "
-                 "analysis errors. It is recommended to use the method "
-                 "fit_calib_data instead")
+        if self._calib_coeffs is not None:
+            if len(self._calib_coeffs) > 0:
+                warn("Resetting calibration coefficients manually. This may introduce "
+                     "analysis errors. It is recommended to use the method "
+                     "fit_calib_data instead")
         self._calib_coeffs = val
 
     @property 


### PR DESCRIPTION
When initializing a `CalibData` object with the `calib_coeffs` argument, they were not set.
`self._calib_coeffs` is initialized as None, so `len(self._calib_coeffs)` will throw an error. However inside __init__ the setting of the `self.calib_coeffs` is inside an try-except block and the error goes unnoticed.
The if statement should fix that but the question remains if the warning is necessary and/or also if an separte object should be avialble which only contains calibration results (which were e.g. obtained from other methods or dummy values for fast visualising of data).