### PR TITLE
Py3 cleanup

### DIFF
--- a/pyplis/fluxcalc.py
+++ b/pyplis/fluxcalc.py
@@ -32,6 +32,7 @@ from .imagelists import ImgList
 from .plumespeed import LocalPlumeProperties
 from .helpers import check_roi, exponent, roi2rect, map_roi
 import six
+import pandas as pd
 from pandas import Series, DataFrame
 try:
     from scipy.constants import N_A
@@ -740,7 +741,7 @@ class EmissionRates(object):
             loaded result data class
 
         """
-        df = DataFrame.from_csv(path)
+        df = pd.read_csv(path)
         return self.from_pandas_dataframe(df)
 
     def __add__(self, other):

--- a/pyplis/imagelists.py
+++ b/pyplis/imagelists.py
@@ -33,6 +33,7 @@ from numpy import (asarray, zeros, argmin, arange, ndarray, float32, isnan,
 from numpy.ma import nomask
 from datetime import timedelta, datetime, date
 
+import pandas as pd
 from pandas import Series, DataFrame
 from matplotlib.pyplot import figure, draw, ion, ioff, close
 from copy import deepcopy
@@ -3665,7 +3666,7 @@ class ImgList(BaseImgList):
 
         The text file requires datetime information in the first column and
         a header which can be used to identify the column. The import is
-        performed using :func:`pandas.DataFrame.from_csv`
+        performed using :func:`pandas.read_csv`
 
         Parameters
         ----------
@@ -3674,7 +3675,7 @@ class ImgList(BaseImgList):
         header_id : str
           header string for column containing ext. coeffs
         **kwargs :
-          additionald keyword args passed to :func:`pandas.DataFrame.from_csv`
+          additionald keyword args passed to :func:`pandas.read_csv`
 
         Returns
         -------
@@ -3685,13 +3686,12 @@ class ImgList(BaseImgList):
         ----
 
         This is a Beta version, insert try / except block after testing
-
         """
         try:
-            df = DataFrame.from_csv(file_path, **kwargs)
+            df = pd.read_csv(file_path, **kwargs)
             s = df[header_id]
         except BaseException:
-            s = Series.from_csv(file_path, **kwargs)
+            s = pd.read_csv(file_path, header=None, index_col=0, squeeze=True, parse_dates=True, **kwargs)
         self.ext_coeffs = s
         return self.ext_coeffs
 

--- a/pyplis/plumespeed.py
+++ b/pyplis/plumespeed.py
@@ -37,6 +37,7 @@ from os import getcwd
 from six.moves import xrange
 import six
 
+import pandas as pd
 from pandas import Series, DataFrame
 
 from cv2 import calcOpticalFlowFarneback, OPTFLOW_FARNEBACK_GAUSSIAN,\
@@ -1820,7 +1821,7 @@ class LocalPlumeProperties(object):
         self.to_pandas_dataframe().to_csv(path)
 
     def load_txt(self, path):
-        df = DataFrame.from_csv(path)
+        df = pd.read_csv(path)
         return self.from_pandas_dataframe(df)
 
     def __setitem__(self, key, val):

--- a/pyplis/test/test_highlevel_examples.py
+++ b/pyplis/test/test_highlevel_examples.py
@@ -128,6 +128,7 @@ def plume_dataset(setup):
     # The dataset takes care of finding all vali
     return pyplis.Dataset(setup)
 
+
 @pytest.fixture(scope="function")
 def aa_image_list(plume_dataset, bg_img_on, bg_img_off, viewing_direction):
     """Prepare AA image list for further analysis."""
@@ -190,9 +191,11 @@ def line():
     return pyplis.LineOnImage(630, 780, 1000, 350, pyrlevel_def=0,
                               normal_orientation="left")
 
+
 @pytest.fixture(scope="function")
 def geometry(plume_dataset):
     return plume_dataset.meas_geometry
+
 
 @pytest.fixture(scope="function")
 def viewing_direction(geometry):
@@ -235,10 +238,11 @@ def test_setup(setup):
 
 def test_dataset(plume_dataset):
     """Test certain properties of the dataset object."""
-    keys = list(plume_dataset.img_lists_with_data.keys())
-    vals_exact = [plume_dataset.img_lists["on"].nof + plume_dataset.img_lists["off"].nof,
-                  sum(plume_dataset.current_image("on").shape),
-                  keys[0], keys[1], plume_dataset.cam_id]
+    ds = plume_dataset
+    keys = list(ds.img_lists_with_data.keys())
+    vals_exact = [ds.img_lists["on"].nof + ds.img_lists["off"].nof,
+                  sum(ds.current_image("on").shape),
+                  keys[0], keys[1], ds.cam_id]
 
     nominal_exact = [178, 2368, "on", "off", "ecII"]
 
@@ -247,8 +251,7 @@ def test_dataset(plume_dataset):
 
 def test_find_viewdir(viewing_direction):
     """Correct viewing direction using location of Etna SE crater."""
-
-    vals = [viewing_direction.cam_azim, viewing_direction.cam_azim_err, 
+    vals = [viewing_direction.cam_azim, viewing_direction.cam_azim_err,
             viewing_direction.cam_elev, viewing_direction.cam_elev_err]
     npt.assert_allclose(actual=vals,
                         desired=[280.21752138146036, 1.0656706289128692, 
@@ -274,8 +277,8 @@ def test_line(line):
     l1 = line.convert(1, [100, 100, 1200, 1024])
 
     # compute values to be tested
-    vals = [line.length(), line.normal_theta, n1, n2, l1.length() / line.length(),
-            sum(l1.roi_def)]
+    vals = [line.length(), line.normal_theta, n1, n2,
+            l1.length() / line.length(), sum(l1.roi_def)]
     # set nominal values
     nominal = [567, 310.710846671181, -0.7580108737829234, -0.6522419146504225,
                0.5008818342151675, 1212]
@@ -320,7 +323,6 @@ def test_optflow(plume_img, plume_img_next, line):
 
 def test_auto_cellcalib(calib_dataset):
     """Test if automatic cell calibration works."""
-
     calib_dataset.find_and_assign_cells_all_filter_lists()
     keys = ["on", "off"]
     nominal = [6., 845.50291, 354.502678, 3., 3.]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,10 @@ scipy
 pandas
 astropy
 matplotlib
-basemap
-opencv
-geonum
+git+git://github.com/matplotlib/basemap#egg=basemap
+opencv-python
+SRTM.py
+LatLon23
+git+git://github.com/jgliss/geonum.git#egg=geonum
 pydoas
 six

--- a/scripts/RUN_EXAMPLE_SCRIPTS.py
+++ b/scripts/RUN_EXAMPLE_SCRIPTS.py
@@ -19,6 +19,7 @@ from __future__ import (absolute_import, division)
 from os import listdir, unlink
 from os.path import basename, join, isfile
 from time import time
+from sys import exit
 from SETTINGS import OPTPARSE
 
 (options, args) = OPTPARSE.parse_args()
@@ -87,3 +88,4 @@ if int(options.test):
         print("None")
 
 print("Total runtime: %.2f s" % (t1 - t0))
+exit(len(test_err_messages))

--- a/scripts/RUN_INTRO_SCRIPTS.py
+++ b/scripts/RUN_INTRO_SCRIPTS.py
@@ -20,6 +20,7 @@ from os import listdir, unlink
 from os.path import basename, join, isfile
 from traceback import format_exc
 from SETTINGS import OPTPARSE
+from sys import exit
 from time import time
 
 paths = [f for f in listdir(".") if f[:4] == "ex0_" and f[4] != "5" and
@@ -88,3 +89,4 @@ if int(options.test):
         print("None")
 
 print("Total runtime: %.2f s" % (t1 - t0))
+exit(len(test_err_messages))

--- a/scripts/ex06_doas_calib.py
+++ b/scripts/ex06_doas_calib.py
@@ -178,69 +178,70 @@ def get_stack(reload_stack=RELOAD_STACK, stack_path=STACK_PATH,
 
     return stack, aa_list
 
-### Test functions used at the end of the script
+
+# Test functions used at the end of the script
 def test_calib_pears_init(calib):
     calib.fit_calib_data(polyorder=1)
     cc = pyplis.helpers.get_img_maximum(calib.fov.corr_img.img)
-    assert cc == (124, 159),  cc
-    
+    npt.assert_allclose(cc, (124, 159), atol=1)
+
     pyrl = calib.fov.pyrlevel
     assert pyrl == 2, pyrl
     res_dict = calib.fov.result_pearson
-    npt.assert_allclose([res_dict['rad_rel'], 
-                         np.max(100*res_dict['corr_curve'].values)],
+    npt.assert_allclose([res_dict['rad_rel'],
+                         np.max(100 * res_dict['corr_curve'].values)],
                         [3, 95], atol=1)
-    
+
     fov_ext = calib.fov.pixel_extend(abs_coords=True)
     (fov_x, fov_y) = calib.fov.pixel_position_center(abs_coords=True)
-    
-    
+
     npt.assert_allclose([fov_ext, fov_x, fov_y],
-                        [res_dict['rad_rel']*2**pyrl, 636, 496], atol=1)
-    
-    
+                        [res_dict['rad_rel'] * 2**pyrl, 636, 496], atol=5)
+
     npt.assert_allclose(calib.calib_coeffs,
                         [8.58e+18, 2.71e+17], rtol=1e-1)
-  
+
+
 def test_calib_pears_fine(calib):
     cc = pyplis.helpers.get_img_maximum(calib.fov.corr_img.img)
-    npt.assert_allclose((186, 180),  cc, atol=1)
-    
+    npt.assert_allclose((186, 180), cc, atol=10)
+
     pyrl = calib.fov.pyrlevel
     assert pyrl == 0, pyrl
     res_dict = calib.fov.result_pearson
-    npt.assert_allclose([res_dict['rad_rel'], 
-                         np.max(100*res_dict['corr_curve'].values)],
+    npt.assert_allclose([res_dict['rad_rel'],
+                         np.max(100 * res_dict['corr_curve'].values)],
                         [6, 95], atol=1)
-    
+
     fov_ext = calib.fov.pixel_extend(abs_coords=True)
     (fov_x, fov_y) = calib.fov.pixel_position_center(abs_coords=True)
-    
-    
+
     npt.assert_allclose([fov_ext, fov_x, fov_y],
                         [6, 630, 493], atol=1)
-    
+
     npt.assert_allclose(calib.calib_coeffs,
                         [8.38e+18, 2.92e+17], rtol=1e-1)
-    
+
+
 def test_calib_ifr(calib):
     cc = pyplis.helpers.get_img_maximum(calib.fov.corr_img.img)
-    npt.assert_allclose((123, 157), cc, atol=1)
-    
+    npt.assert_allclose(cc, (123, 157), atol=1)
+
     pyrl = calib.fov.pyrlevel
     assert pyrl == 2, pyrl
     npt.assert_allclose(calib.fov.result_ifr['popt'][1:5],
-                        [158.6, 122.9, 15.4, 1.5], rtol=1e-1)
-    
+                        [158.6, 122.9, 15.4, 1.5], rtol=.3)
+
     (fov_x, fov_y) = calib.fov.pixel_position_center(abs_coords=True)
-    
+
     npt.assert_allclose([fov_x, fov_y, calib_ifr.fov.sigma_x_abs,
                          calib_ifr.fov.sigma_y_abs],
-                        [635, 492, 61.5, 41.6], atol=2)
-    
-    
+                        [635, 492, 61.5, 41.6], atol=5)
+
     npt.assert_allclose(calib.calib_coeffs,
-                        [9.38e+18, 1.75e+17], rtol=1e-1)
+                        [9.38e+18, 1.75e+17], rtol=.5)
+
+
 # SCRIPT MAIN FUNCTION
 if __name__ == "__main__":
     # close all plots
@@ -268,17 +269,17 @@ if __name__ == "__main__":
     s = pyplis.doascalib.DoasFOVEngine(stack, doas_time_series)
     calib_pears = s.perform_fov_search(method="pearson")
     calib_ifr = s.perform_fov_search(method="ifr", ifrlbda=4e-3)
-    
+
     # plot the FOV search results
     ax0 = calib_pears.fov.plot()
     ax1 = calib_ifr.fov.plot()
 
     calib_pears.fit_calib_data()
     calib_ifr.fit_calib_data()
-    
+
     fig, ax2 = subplots(1, 1)
     calib_pears.plot(add_label_str="Pearson", color="b", ax=ax2)
-    
+
     calib_ifr.plot(add_label_str="IFR", color="g", ax=ax2)
     ax2.set_title("Calibration curves Pearson vs. IFR method")
     ax2.grid()
@@ -295,7 +296,7 @@ if __name__ == "__main__":
             aa_list = prepare_aa_image_list()
         # remember some properties of the current image stack that is stored in
         # the DoasFOVEngine object (i.e. the merged one in low pixel res.)
-        
+
         num_merge, h, w = s.img_stack.shape
         s_fine = s.run_fov_fine_search(aa_list, doas_time_series,
                                        method="pearson")
@@ -333,7 +334,7 @@ if __name__ == "__main__":
     # option --test 1
     if int(options.test):
         from os.path import basename
-        
+
         num, h, w = stack.shape
         num2 = s.img_stack.shape[0]  # stack after fine FOV search
         prep = stack.img_prep
@@ -344,11 +345,11 @@ if __name__ == "__main__":
             [len(doas_time_series), num, num_merge, h, w, stack.pyrlevel,
              prep["darkcorr"] * prep["is_tau"] * prep["is_aa"], num2],
             [120, 209, 88, 256, 336, 2, 1, 209])
-        
+
         test_calib_pears_init(calib_pears)
         test_calib_ifr(calib_ifr)
         test_calib_pears_fine(calib_pears_fine)
-        
+
         print("All tests passed in script: %s" % basename(__file__))
     try:
         if int(options.show) == 1:

--- a/scripts/ex06_doas_calib.py
+++ b/scripts/ex06_doas_calib.py
@@ -183,7 +183,7 @@ def get_stack(reload_stack=RELOAD_STACK, stack_path=STACK_PATH,
 def test_calib_pears_init(calib):
     calib.fit_calib_data(polyorder=1)
     cc = pyplis.helpers.get_img_maximum(calib.fov.corr_img.img)
-    npt.assert_allclose(cc, (124, 159), atol=1)
+    assert cc == (124, 159), cc
 
     pyrl = calib.fov.pyrlevel
     assert pyrl == 2, pyrl
@@ -196,7 +196,7 @@ def test_calib_pears_init(calib):
     (fov_x, fov_y) = calib.fov.pixel_position_center(abs_coords=True)
 
     npt.assert_allclose([fov_ext, fov_x, fov_y],
-                        [res_dict['rad_rel'] * 2**pyrl, 636, 496], atol=5)
+                        [res_dict['rad_rel'] * 2**pyrl, 636, 496], atol=1)
 
     npt.assert_allclose(calib.calib_coeffs,
                         [8.58e+18, 2.71e+17], rtol=1e-1)
@@ -204,7 +204,7 @@ def test_calib_pears_init(calib):
 
 def test_calib_pears_fine(calib):
     cc = pyplis.helpers.get_img_maximum(calib.fov.corr_img.img)
-    npt.assert_allclose((186, 180), cc, atol=10)
+    npt.assert_allclose((186, 180), cc, atol=1)
 
     pyrl = calib.fov.pyrlevel
     assert pyrl == 0, pyrl
@@ -225,21 +225,21 @@ def test_calib_pears_fine(calib):
 
 def test_calib_ifr(calib):
     cc = pyplis.helpers.get_img_maximum(calib.fov.corr_img.img)
-    npt.assert_allclose(cc, (123, 157), atol=1)
+    npt.assert_allclose((123, 157), cc, atol=1)
 
     pyrl = calib.fov.pyrlevel
     assert pyrl == 2, pyrl
     npt.assert_allclose(calib.fov.result_ifr['popt'][1:5],
-                        [158.6, 122.9, 15.4, 1.5], rtol=.3)
+                        [158.6, 122.9, 15.4, 1.5], rtol=1e-1)
 
     (fov_x, fov_y) = calib.fov.pixel_position_center(abs_coords=True)
 
     npt.assert_allclose([fov_x, fov_y, calib_ifr.fov.sigma_x_abs,
                          calib_ifr.fov.sigma_y_abs],
-                        [635, 492, 61.5, 41.6], atol=5)
+                        [635, 492, 61.5, 41.6], atol=2)
 
     npt.assert_allclose(calib.calib_coeffs,
-                        [9.38e+18, 1.75e+17], rtol=.5)
+                        [9.38e+18, 1.75e+17], rtol=1e-1)
 
 
 # SCRIPT MAIN FUNCTION

--- a/scripts/ex09_velo_optflow.py
+++ b/scripts/ex09_velo_optflow.py
@@ -96,7 +96,7 @@ def analyse_and_plot(lst, lines):
     ax2.set_ylim([0, ymax])
 
     ax2.set_title("")
-    # ax2.legend_.remove()
+    ax2.legend_.remove()
 
     sca(ax1)
     xticks(rotation=40, ha="right")
@@ -184,12 +184,13 @@ if __name__ == "__main__":
 # ==============================================================================
 
         fig, ax = subplots(2, 1, figsize=(10, 9))
+
         plume_props_l1.plot_directions(ax=ax[0],
                                        color=PCS1.color,
                                        label="PCS1")
         plume_props_l2.plot_directions(ax=ax[0], color=PCS2.color,
                                        label="PCS2")
-    
+
         plume_props_l1.plot_magnitudes(normalised=True, ax=ax[1],
                                        date_fmt="%H:%M:%S", color=PCS1.color,
                                        label="PCS1")

--- a/scripts/ex0_2_camera_setup.py
+++ b/scripts/ex0_2_camera_setup.py
@@ -57,14 +57,14 @@ def create_ecII_cam_new_filters():
 
     # Specify the camera filter setup
 
-    # create an on and off band filters, obligatory input is param "type" and
-    # acronym", the former specifies the filter type (choose from "on" or
-    # "off"), the acronym specifies, how to identify this filter in the file
-    # name, if id is unspecified it will be set equal the type. Param
-    # meas_type_acro is only of importance if a meas type (e.g. M -> meas,
-    # C -> calib ...) is explicitely specified in the file names (not the case
-    # for ECII camera but for the HD camera, see specifications in file
-    # cam_info.txt for more info)
+    # Create on and off band filters. Obligatory parameters are "type" and
+    # "acronym", "type" specifies the filter type ("on" or
+    # "off"), "acronym" specifies how to identify this filter in the file
+    # name. If "id" is unspecified it will be equal to "type". The parameter
+    # "meas_type_acro" is only important if a measurement type (e.g. M -> meas,
+    # C -> calib ...) is explicitely specified in the file name.
+    # This is not the case for ECII camera but for the HD camera,
+    # see specifications in file cam_info.txt for more info.
 
     on_band = pyplis.utils.Filter(id="on", type="on", acronym="F01",
                                   meas_type_acro="F01", center_wavelength=310)

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,9 @@ deps = -r{toxinidir}/requirements.txt
        py{3,35,36,37}: -r{toxinidir}/test-requirements-py3.txt
 commands = pytest {posargs}
 
+[pytest]
+testpaths = pyplis
+
 [testenv:scripts]
 changedir = {toxinidir}/scripts
 commands =  python RUN_INTRO_SCRIPTS.py


### PR DESCRIPTION
Some lint cleanup and wording commits, an odd pytest fix (fed120a) caused by a bug in astropy, improve error handling in tests scripts (c88c817) which would otherwise run happily and report no problems even if tests failed, as well as a fixed requirements file for tox (c28dd7c).

Also replaced from_csv with read_csv (fc70375) as the first has been deprecated and removed:
- https://pandas.pydata.org/pandas-docs/stable/whatsnew/v0.25.0.html?highlight=from_csv#removal-of-prior-version-deprecations-changes
- https://github.com/pandas-dev/pandas/issues/4191
